### PR TITLE
Handle Uppercase Strings

### DIFF
--- a/packages/client/src/renderer/Hue/Hue.svelte
+++ b/packages/client/src/renderer/Hue/Hue.svelte
@@ -11,7 +11,7 @@
             await hue.setScene(item.scene);
         } else {
             try {
-                const rgb = color(item.userInput).array();
+                const rgb = color(item.userInput.toLowerCase()).array();
                 await hue.setLights(rgb);
             } catch (e) {
                 console.warn('Unknown color, did not set lights to any color');


### PR DESCRIPTION
Fix issue where uppercase strings wouldn't convert properly.
`GoldenRod` would break. It now converts to `goldenrod` which can be parsed by the color library.